### PR TITLE
Remove ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
         config:
           - os: 'ubuntu-2204'
             container: 'ubuntu:22.04'
-          - os: 'ubuntu-2004'
-            container: 'ubuntu:20.04'
+          - os: 'ubuntu-latest'
+            container: 'ubuntu:latest'
           - os: 'debian-bullseye'
             container: 'debian:bullseye'
           - os: 'debian-bookworm'
@@ -243,7 +243,7 @@ jobs:
             use_composite: true
       fail-fast: false
 
-    runs-on: ${{ matrix.config.use_composite && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.config.use_composite && 'ubuntu-22.04' || 'ubuntu-latest' }}
     container: ${{ !matrix.config.use_composite && matrix.config.container || '' }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,11 +238,9 @@ jobs:
           - os: 'rocky-8'
             container: 'quay.io/rockylinux/rockylinux:8'
             use_composite: true
-            extra_repo: 'powertools'
           - os: 'rocky-9'
             container: 'quay.io/rockylinux/rockylinux:9'
             use_composite: true
-            extra_repo: 'crb'
       fail-fast: false
 
     runs-on: ${{ matrix.config.use_composite && 'ubuntu-22.04' || 'ubuntu-latest' }}
@@ -306,13 +304,15 @@ jobs:
           bash -c '
             set -ex
             
-            # Detect OS and setup repositories
+            # Detect OS and setup repositories for Rocky Linux
             if [ -f /etc/rocky-release ]; then
               dnf install -y dnf-plugins-core
-              dnf config-manager --set-enabled powertools
-            elif [ -f /etc/centos-release ]; then
-              sed -i "s/mirrorlist/#mirrorlist/g" /etc/yum.repos.d/CentOS-*
-              sed -i "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-*
+              # Detect Rocky version and enable appropriate repo
+              if grep -q "release 8" /etc/rocky-release; then
+                dnf config-manager --set-enabled powertools
+              elif grep -q "release 9" /etc/rocky-release; then
+                dnf config-manager --set-enabled crb
+              fi
             fi
             
             # Install dependencies based on package manager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,11 +235,11 @@ jobs:
             container: 'debian:bookworm'
           - os: 'fedora-latest'
             container: 'fedora:latest'
-          - os: 'centos-7'
-            container: 'quay.io/centos/centos:7'
-            use_composite: true
           - os: 'rocky-8'
             container: 'quay.io/rockylinux/rockylinux:8'
+            use_composite: true
+          - os: 'rocky-9'
+            container: 'quay.io/rockylinux/rockylinux:9'
             use_composite: true
       fail-fast: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,9 +238,11 @@ jobs:
           - os: 'rocky-8'
             container: 'quay.io/rockylinux/rockylinux:8'
             use_composite: true
+            extra_repo: 'powertools'
           - os: 'rocky-9'
             container: 'quay.io/rockylinux/rockylinux:9'
             use_composite: true
+            extra_repo: 'crb'
       fail-fast: false
 
     runs-on: ${{ matrix.config.use_composite && 'ubuntu-22.04' || 'ubuntu-latest' }}


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Remove Ubuntu 20.04 from CI matrix and runners

- Update to use Ubuntu 22.04 and latest images in CI

- Adjust composite runner logic to use Ubuntu 22.04


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Remove Ubuntu 20.04 and update CI to newer Ubuntu</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<li>Removed Ubuntu 20.04 from the CI matrix and runners<br> <li> Replaced with Ubuntu 22.04 and Ubuntu latest images<br> <li> Updated composite runner logic to use Ubuntu 22.04


</details>


  </td>
  <td><a href="https://github.com/midorinet/ngx_upstream_mgmt/pull/5/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>